### PR TITLE
Format code and check linting on CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Linting
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  lint:
+    name: Lint checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Check deno fmt
+        run: deno fmt --check

--- a/readme.md
+++ b/readme.md
@@ -34,3 +34,13 @@ The resulting output can be found in `./out`.
 ## Limitations
 
 See `./src/networks.ts` for a full list of supported networks.
+
+## Development
+
+### Code formatting
+
+Run the following command to format the code to this project's standards:
+
+```sh
+deno fmt
+```

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # Safe Multisig Owner replacer
 
-Build a transaction to optimally change the owners of a Safe Multisigs to match a given list.
+Build a transaction to optimally change the owners of a Safe Multisigs to match
+a given list.
 
 ## Requirements
 
@@ -9,15 +10,18 @@ Build a transaction to optimally change the owners of a Safe Multisigs to match 
 ## Usage
 
 > [!TIP]
-> This repository can be run in a devcontainer directly from within github without the need for a local setup.
+> This repository can be run in a devcontainer directly from within github
+> without the need for a local setup.
 
 The file `./config.ts` specifies all safes to consider, and, for each:
+
 - the network they live in,
 - the list of new owners, and
 - the new threshold.
 
-The script generates a transaction file for each Safe.
-You can use the transaction builder on the Safe interface to simulate and execute the resulting transaction.
+The script generates a transaction file for each Safe. You can use the
+transaction builder on the Safe interface to simulate and execute the resulting
+transaction.
 
 Generate the transaction files with:
 

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -25,15 +25,15 @@ export function getRpc(network: SupportedNetworks): string {
     case "Arbitrum One":
       return "https://arbitrum-one-rpc.publicnode.com";
     case "Base":
-      return "https://base.llamarpc.com"
+      return "https://base.llamarpc.com";
     case "Bsc":
-      return "https://bsc-dataseed.binance.org"
+      return "https://bsc-dataseed.binance.org";
     case "Polygon":
-      return "https://polygon-rpc.com/"
+      return "https://polygon-rpc.com/";
     case "Optimism":
-      return "https://mainnet.optimism.io"
+      return "https://mainnet.optimism.io";
     case "Avalanche":
-      return "https://api.avax.network/ext/bc/C/rpc"
+      return "https://api.avax.network/ext/bc/C/rpc";
     case "Lens":
       return "https://rpc.lens.xyz";
     default:


### PR DESCRIPTION
A replacement for #4 that uses the default Deno formatter instead of the Prettier one to avoid needing an extra tool to work on this repo.

It also checks for proper formatting on CI.

### How to test

Check that CI runs successfully.