### PR TITLE
Add Linea and Plasma support

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,8 @@ base_path="$(dirname "$(realpath -s "$0")")/src"
 # Explanation for the flags:
 # - `NODE_EXTRA_CA_CERTS`: if using ethers npm package and this is denied, the
 #   script errors out with "Error: could not detect network".
+# - `WS_NO_BUFFER_UTIL`: script crashes without access
+#   https://www.npmjs.com/package/ws?activeTab=readme
 # - `--deny-read`: do not prompt for permission to read the node_modules cache,
 #   which is triggered by the npm module import of ethers.
 # - `--allow-net=...`: list of nodes that the script is expected to connect to.
@@ -14,14 +16,15 @@ base_path="$(dirname "$(realpath -s "$0")")/src"
 deno run \
   --deny-read \
   --allow-write="./out" \
-  --allow-env='NODE_EXTRA_CA_CERTS' \
+  --allow-env='NODE_EXTRA_CA_CERTS,WS_NO_BUFFER_UTIL' \
   --allow-net="\
 rpc.mevblocker.io,\
 rpc.gnosischain.com,\
 ethereum-sepolia.publicnode.com,\
 arbitrum-one-rpc.publicnode.com,\
 base.llamarpc.com,\
-rpc.lens.xyz" \
+rpc.lens.xyz,\
+rpc.linea.build" \
   -- \
   "$base_path/replace-owners.ts" \
   "$@"

--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,8 @@ ethereum-sepolia.publicnode.com,\
 arbitrum-one-rpc.publicnode.com,\
 base.llamarpc.com,\
 rpc.lens.xyz,\
-rpc.linea.build" \
+rpc.linea.build,\
+rpc.plasma.to" \
   -- \
   "$base_path/replace-owners.ts" \
   "$@"

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -10,7 +10,8 @@ export type SupportedNetworks =
   | "Arbitrum One"
   | "Base"
   | "Lens"
-  | "Linea";
+  | "Linea"
+  | "Plasma";
 
 export function getRpc(network: SupportedNetworks): string {
   // For more information about the RPC nodes: https://chainlist.org/
@@ -39,6 +40,8 @@ export function getRpc(network: SupportedNetworks): string {
       return "https://rpc.lens.xyz";
     case "Linea":
       return "https://rpc.linea.build";
+    case "Plasma":
+      return "https://rpc.plasma.to";
     default:
       throw new Error(`Invalid network ${network}`);
   }

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -9,7 +9,8 @@ export type SupportedNetworks =
   | "Avalanche"
   | "Arbitrum One"
   | "Base"
-  | "Lens";
+  | "Lens"
+  | "Linea";
 
 export function getRpc(network: SupportedNetworks): string {
   // For more information about the RPC nodes: https://chainlist.org/
@@ -36,6 +37,8 @@ export function getRpc(network: SupportedNetworks): string {
       return "https://api.avax.network/ext/bc/C/rpc";
     case "Lens":
       return "https://rpc.lens.xyz";
+    case "Linea":
+      return "https://rpc.linea.build";
     default:
       throw new Error(`Invalid network ${network}`);
   }


### PR DESCRIPTION
Adds support for Linea ([context](https://cowservices.slack.com/archives/C037UV49JLR/p1760005710304889)) and Plasma ([context](https://cowservices.slack.com/archives/C037UV49JLR/p1760098059727309)) chains.

Additionally, I let the script access the env `WS_NO_BUFFER_UTIL`. It looks like running the script crashes without access to that var so it's basically required. It's independent of the other changes in the PR. It appears to be related to `ws`, a transitive dependency of Ethers. I didn't investigate further since it's a minor issue.

### How to test

You can run the script using the following config file and import it in [the transaction builder with the relevant safe](https://app.safe.global/apps/open?safe=linea%3A0x423cec87f19f0778f549846e0801ee267a917935&appUrl=https%3A%2F%2Fapps-portal.safe.global%2Ftx-builder).

<details><summary>config.ts</summary>

```js
import { SingleSafeConfig } from "./src/types.ts";

const owners = [
  "0x1111111111111111111111111111111111111111",
  "0x2222222222222222222222222222222222222222",
  "0x3333333333333333333333333333333333333333",
  "0x4444444444444444444444444444444444444444",
  "0x5555555555555555555555555555555555555555",
];
export const safesToUpdate: SingleSafeConfig[] = [
  {
    safe: "0x423cEc87f19F0778f549846e0801ee267a917935",
    network: "Linea",
    newThreshold: 3,
    newOwners: owners,
  }
];
```
</details>

<details><summary>Expected result</summary>

<img width="426" height="920" alt="image" src="https://github.com/user-attachments/assets/212567f2-5e28-404d-bf8c-68632f6b2faa" />

</details>