### PR TITLE
Update deno installation procedure

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/base:1-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/base:2-trixie
 
 ENV DENO_INSTALL=/deno
 RUN mkdir -p /deno \
-    && curl -fsSL https://deno.land/x/install/install.sh | sh \
+    && curl -fsSL https://deno.land/install.sh | sh \
     && chown -R vscode /deno
 
 ENV PATH=${DENO_INSTALL}/bin:${PATH} \


### PR DESCRIPTION
Changes related to the devcontainer.

- Updates the [Deno installation URL](https://docs.deno.com/runtime/getting_started/installation/) (the current one doesn't point to anything valid).
- Updates the base image for the container (not strictly necessary but having updated GLIBC helps for many tools).
- Remove the enforced platform (I noticed a warning when building, [here](https://docs.docker.com/reference/build-checks/from-platform-flag-const-disallowed/) are the details on why it isn't needed.

### How to test

Rebuild your devcontainer and make sure that `./run.sh` works.