### PR TITLE
Automatically pick up URLs for --allow-net

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,5 +19,8 @@ jobs:
         with:
           deno-version: v2.x
 
+      - name: Confirm that it builds
+        run: deno check ./src
+
       - name: Check deno fmt
         run: deno fmt --check

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /out
 *.csv
-*.json

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,20 @@ set -o errexit -o nounset -o pipefail
 
 base_path="$(dirname "$(realpath -s "$0")")/src"
 
+rpc_file="${base_path}/rpcs.json"
+comma_separated_rpc_base_urls=$(
+  jq --raw-output \
+    '.[]
+       | .url
+         # remove the protocol (like https) by removing everything before `//`
+       | sub(".*//"; "")
+         # only take base URL by removing everything after `/`
+       | sub("/.*"; "")
+    ' "$rpc_file" \
+    | tr '\n' ',' \
+    | head --bytes=-1
+)
+
 # Explanation for the flags:
 # - `NODE_EXTRA_CA_CERTS`: if using ethers npm package and this is denied, the
 #   script errors out with "Error: could not detect network".
@@ -17,16 +31,7 @@ deno run \
   --deny-read \
   --allow-write="./out" \
   --allow-env='NODE_EXTRA_CA_CERTS,WS_NO_BUFFER_UTIL' \
-  --allow-net="\
-rpc.mevblocker.io,\
-rpc.gnosischain.com,\
-ethereum-sepolia.publicnode.com,\
-arbitrum-one-rpc.publicnode.com,\
-base.llamarpc.com,\
-rpc.lens.xyz,\
-rpc.linea.build,\
-rpc.plasma.to,\
-ink.drpc.org" \
+  --allow-net="$comma_separated_rpc_base_urls" \
   -- \
   "$base_path/replace-owners.ts" \
   "$@"

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -1,3 +1,5 @@
+import importedRpcs from "./rpcs.json" with { type: "json" };
+
 // Network names based on .name in: https://github.com/ethereum-lists/chains/tree/master/_data/chains
 export type SupportedNetworks =
   | "Ethereum Mainnet"
@@ -14,39 +16,18 @@ export type SupportedNetworks =
   | "Plasma"
   | "Ink";
 
+// This line is here to type check the JSON file, so that the compiler throws an
+// error if a network is missing from the JSON object.
+export const rpcs: Record<
+  SupportedNetworks,
+  { url: string; comment?: string }
+> = importedRpcs;
+
 export function getRpc(network: SupportedNetworks): string {
   // For more information about the RPC nodes: https://chainlist.org/
-  switch (network) {
-    case "Ethereum Mainnet":
-      // https://mevblocker.io/#rpc
-      return "https://rpc.mevblocker.io";
-    case "Gnosis":
-      // https://docs.gnosischain.com/tools/rpc/
-      return "https://rpc.gnosischain.com";
-    case "Sepolia":
-      return "https://ethereum-sepolia.publicnode.com";
-    case "Arbitrum One":
-      return "https://arbitrum-one-rpc.publicnode.com";
-    case "Base":
-      return "https://base.llamarpc.com";
-    case "Bsc":
-      return "https://bsc-dataseed.binance.org";
-    case "Polygon":
-      return "https://polygon-rpc.com/";
-    case "Optimism":
-      return "https://mainnet.optimism.io";
-    case "Avalanche":
-      return "https://api.avax.network/ext/bc/C/rpc";
-    case "Lens":
-      return "https://rpc.lens.xyz";
-    case "Linea":
-      return "https://rpc.linea.build";
-    case "Plasma":
-      return "https://rpc.plasma.to";
-    case "Ink":
-      // https://docs.inkonchain.com/tools/rpc
-      return "https://ink.drpc.org";
-    default:
-      throw new Error(`Invalid network ${network}`);
+  const url = rpcs[network].url;
+  if (typeof url != "string") {
+    throw new Error(`Invalid network ${network}`);
   }
+  return url;
 }

--- a/src/rpcs.json
+++ b/src/rpcs.json
@@ -1,0 +1,24 @@
+{
+  "Ethereum Mainnet": {
+    "comment": "https://mevblocker.io/#rpc",
+    "url": "https://rpc.mevblocker.io"
+  },
+  "Gnosis": {
+    "comment": "https://docs.gnosischain.com/tools/rpc/",
+    "url": "https://rpc.gnosischain.com"
+  },
+  "Sepolia": { "url": "https://ethereum-sepolia.publicnode.com" },
+  "Arbitrum One": { "url": "https://arbitrum-one-rpc.publicnode.com" },
+  "Base": { "url": "https://base.llamarpc.com" },
+  "Bsc": { "url": "https://bsc-dataseed.binance.org" },
+  "Polygon": { "url": "https://1rpc.io/matic" },
+  "Optimism": { "url": "https://mainnet.optimism.io" },
+  "Avalanche": { "url": "https://api.avax.network/ext/bc/C/rpc" },
+  "Lens": { "url": "https://rpc.lens.xyz" },
+  "Linea": { "url": "https://rpc.linea.build" },
+  "Plasma": { "url": "https://rpc.plasma.to" },
+  "Ink": {
+    "comment": "https://ink.drpc.org",
+    "url": "https://docs.inkonchain.com/tools/rpc"
+  }
+}


### PR DESCRIPTION
Quality of life change.
Deno prompts to confirm when the script makes any network request. This means that when we add a new network we also need to remember to add an exception in `--allow-net`. This is very often forgotten, for example right now it's missing `api.avax.network` and `polygon-rpc.com`.

<details><summary>Example prompt</summary>

```
┏ ⚠️  Deno requests net access to "api.avax.network:443".
┠─ Requested by `node:dns.lookup()` API.
┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.
┠─ Learn more at: https://docs.deno.com/go/--allow-net
┠─ Run again with --allow-net to bypass this prompt.
┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all net permissions) > 
error: Uncaught (in promise) Error: could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.8.0)
    at Logger.makeError (file:///deno/.cache/deno/npm/registry.npmjs.org/@ethersproject/logger/5.8.0/lib/index.js:238:21)
    at Logger.throwError (file:///deno/.cache/deno/npm/registry.npmjs.org/@ethersproject/logger/5.8.0/lib/index.js:247:20)
    at JsonRpcProvider.<anonymous> (file:///deno/.cache/deno/npm/registry.npmjs.org/@ethersproject/providers/5.8.0/lib/json-rpc-provider.js:609:54)
    at step (file:///deno/.cache/deno/npm/registry.npmjs.org/@ethersproject/providers/5.8.0/lib/json-rpc-provider.js:48:23)
    at Object.throw (file:///deno/.cache/deno/npm/registry.npmjs.org/@ethersproject/providers/5.8.0/lib/json-rpc-provider.js:29:53)
    at rejected (file:///deno/.cache/deno/npm/registry.npmjs.org/@ethersproject/providers/5.8.0/lib/json-rpc-provider.js:21:65)
    at Object.runMicrotasks (ext:core/01_core.js:693:26)
    at Array.processTicksAndRejections (ext:deno_node/_next_tick.ts:59:10)
    at eventLoopTick (ext:core/01_core.js:176:29)
```

</details>

With these changes, the RPC information is moved to a JSON file and this file is read in `run.sh` to extract the base URL automatically.
The JSON file is also type checked by the compiler to make sure that we aren't forgetting any networks, and this check is added to CI.

I also changed the RPC URL for Polygon since it wasn't working (from `https://polygon-rpc.com` to `https://1rpc.io/matic`).

### How to test

Try the script with a config file that touches many networks, for example the following, and see that everything works.

<details><summary>./config.ts</summary>

```ts
import { SingleSafeConfig } from "./src/types.ts";

const owners = [
  "0x1c20Fd4b76E2ec0BFd417eD18C02F45c1e8190C0",
  "0xc7d9e9D8fCC0060a21C8401C50483A8b2cCc8200",
  "0xc3792470cee7e0D42C2Be8e9552bd651766c5178",
  "0xf6d3a588dF6C4eEe8F095CbcCDBDACccCBf59A18",
  "0x79063d9173C09887d536924E2F6eADbaBAc099f5",
  "0xD118ebD98C6445853ec03E036eC67a22a829Ff03",
  "0xCF89198fb5f37C98516bC36c6111a431ff7457b2",
  "0xdEF4cb94150E7A7349d2650dCD974a236c0Fa374",
  "0xd0e93CD8462a9Abb41d3713e4376904420FD0AE0",
  "0x34872330F5D08C18dd0ef3CB4Dd8908104F3763B",
  "0x6648867EF1AaE43a5d3bef774312815c4950a065",
];
export const safesToUpdate: SingleSafeConfig[] = [
  {
    safe: "0xCa8a6c454bbcCb2017Eb37E075CFea813b4deA59",
    network: "Ethereum Mainnet",
    newThreshold: 4,
    newOwners: owners,
  },
  {
    safe: "0xCa8a6c454bbcCb2017Eb37E075CFea813b4deA59",
    network: "Gnosis",
    newThreshold: 4,
    newOwners: owners,
  },
  {
    safe: "0xCa8a6c454bbcCb2017Eb37E075CFea813b4deA59",
    network: "Arbitrum One",
    newThreshold: 4,
    newOwners: owners,
  },
  {
    safe: "0xCa8a6c454bbcCb2017Eb37E075CFea813b4deA59",
    network: "Base",
    newThreshold: 4,
    newOwners: owners,
  },
  {
    safe: "0xCa8a6c454bbcCb2017Eb37E075CFea813b4deA59",
    network: "Avalanche",
    newThreshold: 4,
    newOwners: owners,
  },
  {
    safe: "0xCa8a6c454bbcCb2017Eb37E075CFea813b4deA59",
    network: "Polygon",
    newThreshold: 4,
    newOwners: owners,
  },
  {
    safe: "0xCa8a6c454bbcCb2017Eb37E075CFea813b4deA59",
    network: "Linea",
    newThreshold: 4,
    newOwners: owners,
  },
  {
    safe: "0xCa8a6c454bbcCb2017Eb37E075CFea813b4deA59",
    network: "Plasma",
    newThreshold: 4,
    newOwners: owners,
  },
  {
    safe: "0xCa8a6c454bbcCb2017Eb37E075CFea813b4deA59",
    network: "Bsc",
    newThreshold: 4,
    newOwners: owners,
  },
];
```
</details>

Also, try to add a new network to `SupportedNetworks` and see that `deno check ./src` returns an error.